### PR TITLE
Update usage instructions to fix #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Export the colors of every Catppuccin flavour into various formats. Currently it
 Usage:
 
 ```bash
-$ git clone https://github.com/catppuccin/toolbox.git && cd toolbox
+$ git clone https://github.com/catppuccin/toolbox.git
+$ cd toolbox/palette_builder
 $ npm install	# fetch dependencies
 $ npm start <format> <out_file>
 ```


### PR DESCRIPTION
Navigating to the palette_builder directory before running `npm install` makes sure npm can find a `package.json`.