### PR TITLE
fix: alpha_fit typo (line 48)

### DIFF
--- a/catwalk/catwalk/utils.py
+++ b/catwalk/catwalk/utils.py
@@ -45,7 +45,7 @@ def gen_rainbow(size: Tuple[int, int]) -> Image.Image:
 
 
 def alpha_fit(
-    img1: Image.Image, img2: Image.Image, offset: tuple[int, int] = (0, 0)
+    img1: Image.Image, img2: Image.Image, offset: Tuple[int, int] = (0, 0)
 ) -> Image.Image:
     dest = ((img1.width // 2 - img2.width // 2), (img1.height // 2 - img2.height // 2))
     dest = (dest[0] + offset[0], dest[1] + offset[1])


### PR DESCRIPTION
lowercase "tuple" in line 48 causes TypeError: 'type' object is not subscriptable; fix is to capitalise "T"

I'm not a Python person, but this fixed an issue I was having with Catwalk. Judging by the syntax of the rest of the file, this looks sensical though.