### PR TITLE
docs: add pipx install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,18 @@ cargo install --path .
 
 &nbsp;
 
-#### 🎨Catwalk
+#### 🎨 Catwalk
 
 A sweet program that takes in four showcase images and displays them all at once.
 
-Usage:
+Install with [pipx](https://pypa.github.io/pipx/) (preferred):
+
+```bash
+$ pipx install catppuccin-catwalk
+$ catwalk <images>
+```
+
+Install using pip (inside of a virtual environment):
 
 ```bash
 $ python3 -m pip install --upgrade catppuccin-catwalk
@@ -226,7 +233,7 @@ $ python3 -m catwalk
 ```
 
 | Parameter      | Description                                                                                                                |
-|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| -------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `images`       | 4 images to merge into one. **REQUIRED**. All other parameters are optional.                                               |
 | `--layout`     | Choose the style of the showcase image. Available options are `composite` (default), `grid`, and `stacked`.                |
 | `--gap`        | Size of the gap between the `grid` layout. Defaults to 20px.                                                               |


### PR DESCRIPTION
### What is pipx

- [pipx](https://pypa.github.io/pipx/) is a tool created by the Python Packaging Authority (PyPA)
- pipx is used to install python tools, like our `catwalk`
- pipx automatically creates isolated environments for your python apps, making it ideal for new python users (and those who don't use python at all)

### On Python environments

An isolated env for python apps is critical. With the current instructions, a less informed user might install catwalk to their base env and create hard to reproduce dependency conflicts.

Pillow, the image manipulation dependency used by catwalk, is notorious for decimating environments