### PR TITLE
feat(whiskers): add check mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansiterm"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,15 +166,12 @@ dependencies = [
 name = "catppuccin-whiskers"
 version = "1.0.3"
 dependencies = [
- "ansiterm",
- "atty",
  "base64",
  "catppuccin",
  "clap",
  "clap-stdin",
  "color-eyre",
  "css-colors",
- "diff",
  "handlebars",
  "regex",
  "serde",
@@ -319,12 +307,6 @@ name = "css-colors"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c2bbfc5708f23437b074ba4e699b14fd6d7181a61695bccc8d944b78739236"
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansiterm"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,17 +175,20 @@ dependencies = [
 name = "catppuccin-whiskers"
 version = "1.0.3"
 dependencies = [
+ "ansiterm",
  "base64",
  "catppuccin",
  "clap",
  "clap-stdin",
  "color-eyre",
  "css-colors",
+ "diff",
  "handlebars",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "titlecase",
 ]
@@ -302,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c2bbfc5708f23437b074ba4e699b14fd6d7181a61695bccc8d944b78739236"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +340,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "eyre"
@@ -336,6 +370,12 @@ dependencies = [
  "num-traits",
  "thiserror",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
@@ -470,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,7 +624,7 @@ version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -610,6 +656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -658,6 +713,19 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -741,6 +809,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ name = "catppuccin-whiskers"
 version = "1.0.3"
 dependencies = [
  "ansiterm",
+ "atty",
  "base64",
  "catppuccin",
  "clap",

--- a/whiskers/Cargo.toml
+++ b/whiskers/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 ansiterm = "0.12.2"
+atty = "0.2.14"
 base64 = "0.21.4"
 catppuccin = { version = "1.3.0", features = ["css"] }
 clap = { version = "4.4.6", features = ["derive"] }

--- a/whiskers/Cargo.toml
+++ b/whiskers/Cargo.toml
@@ -14,16 +14,19 @@ name = "whiskers"
 path = "src/main.rs"
 
 [dependencies]
+ansiterm = "0.12.2"
 base64 = "0.21.4"
 catppuccin = { version = "1.3.0", features = ["css"] }
 clap = { version = "4.4.6", features = ["derive"] }
 clap-stdin = "0.2.1"
 color-eyre = { version = "0.6.2", default-features = false }
 css-colors = "1.0.1"
+diff = "0.1.13"
 handlebars = "4.4.0"
 regex = "1.10.2"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
+tempfile = "3.8.1"
 thiserror = "1.0.50"
 titlecase = "2.2.1"

--- a/whiskers/Cargo.toml
+++ b/whiskers/Cargo.toml
@@ -14,15 +14,12 @@ name = "whiskers"
 path = "src/main.rs"
 
 [dependencies]
-ansiterm = "0.12.2"
-atty = "0.2.14"
 base64 = "0.21.4"
 catppuccin = { version = "1.3.0", features = ["css"] }
 clap = { version = "4.4.6", features = ["derive"] }
 clap-stdin = "0.2.1"
 color-eyre = { version = "0.6.2", default-features = false }
 css-colors = "1.0.1"
-diff = "0.1.13"
 handlebars = "4.4.0"
 regex = "1.10.2"
 serde = { version = "1.0.189", features = ["derive"] }

--- a/whiskers/README.md
+++ b/whiskers/README.md
@@ -21,27 +21,17 @@ A templating tool to simplify the creation of Catppuccin ports.
 
 Download the correct file for your system and place it somewhere in your executable path.
 
-### Build from source
-
-If you have a rust toolchain installed, you can build and install Whiskers with cargo.
-
-Install the latest crates.io release:
+Alternatively, you can install with Cargo, Nix, or from source:
 
 ```console
+# latest crates.io release:
 $ cargo install catppuccin-whiskers
-```
+$ whiskers <template> <flavor>
 
-Or the latest source from git:
-
-```console
+# to install from source:
 $ cargo install --git https://github.com/catppuccin/toolbox whiskers
-```
 
-### Nix flake
-
-If you use Nix, you can use Whiskers' flake:
-
-```console
+# there's also a Nix flake:
 $ nix run github:catppuccin/toolbox#whiskers -- <template> <flavor>
 ```
 
@@ -51,6 +41,8 @@ Make a template per file type that your port requires, then use the Whiskers CLI
 
 ```console
 $ whiskers --help
+Soothing port creation tool for the high-spirited!
+
 Usage: whiskers [OPTIONS] [TEMPLATE] [FLAVOR]
 
 Arguments:
@@ -58,8 +50,12 @@ Arguments:
   [FLAVOR]    Flavor to get colors from [possible values: latte, frappe, macchiato, mocha]
 
 Options:
-  -l, --list-helpers  List all template helpers in markdown format
-  -h, --help          Print help
+      --override <OVERRIDES>       The overrides to apply to the template in key=value format
+  -o, --output-path <OUTPUT_PATH>  Path to write to instead of stdout
+      --check <CHECK>              Instead of printing a result just check if anything would change
+  -l, --list-helpers               List all template helpers in markdown format
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 ## Template Syntax

--- a/whiskers/README.md
+++ b/whiskers/README.md
@@ -18,19 +18,23 @@ A templating tool to simplify the creation of Catppuccin ports.
 ## Installation
 
 [Compiled binaries are available for Windows, macOS, and Linux.](https://github.com/catppuccin/toolbox/releases)
+
 Download the correct file for your system and place it somewhere in your executable path.
 
 ### Build from source
 
-If you have a rust toolchain installed, you can build and install Whiskers with cargo:
+If you have a rust toolchain installed, you can build and install Whiskers with cargo.
+
+Install the latest crates.io release:
 
 ```console
-# latest crates.io release:
 $ cargo install catppuccin-whiskers
-# to install from source:
+```
+
+Or the latest source from git:
+
+```console
 $ cargo install --git https://github.com/catppuccin/toolbox whiskers
-# there's also a Nix flake:
-$ nix run github:catppuccin/toolbox#whiskers -- <images> <flags>
 ```
 
 ### Nix flake
@@ -212,6 +216,29 @@ Finally, we can override both values by passing two overrides. If we invoke whis
 bg = "#000000"
 fg = "#f9e2af"
 ```
+
+## Check Mode
+
+You can use Whiskers as a linter with *check mode*. To do so, pass the `--check` option with a file containing the expected output. Whiskers will render your template as per usual, but then instead of printing the result it will check it against the expected output and fail with exit code 1 if they differ.
+
+Set the `DIFFTOOL` environment variable to make Whiskers use that instead of its internal diff.
+
+```console
+$ whiskers theme.hbs latte --check themes/latte.cfg
+# no output, exit code 0
+
+$ whiskers theme.hbs latte --check themes/latte.cfg
+Templating would result in changes:
+ flavor: Latte
+ 
+ parent is default
++accent is #ea76cb
+-accent is #40a02b
+
+# exit code 1
+```
+
+This is especially useful in CI pipelines to ensure that the generated files are not changed without a corresponding change to the templates.
 
 ## Further Reading
 

--- a/whiskers/README.md
+++ b/whiskers/README.md
@@ -215,26 +215,25 @@ fg = "#f9e2af"
 
 ## Check Mode
 
-You can use Whiskers as a linter with *check mode*. To do so, pass the `--check` option with a file containing the expected output. Whiskers will render your template as per usual, but then instead of printing the result it will check it against the expected output and fail with exit code 1 if they differ.
+You can use Whiskers as a linter with *check mode*. To do so, set the `--check` option to a file containing the expected output. Whiskers will render your template as per usual, but then instead of printing the result it will check it against the expected output and fail with exit code 1 if they differ.
 
-Set the `DIFFTOOL` environment variable to make Whiskers use that instead of its internal diff.
+This is especially useful in CI pipelines to ensure that the generated files are not changed without a corresponding change to the templates.
+
+Whiskers will diff the output against the check file using the program set in the `DIFFTOOL` environment variable, falling back to `diff` if it's not set. The command will be invoked as `$DIFFTOOL <actual> <expected>`.
 
 ```console
 $ whiskers theme.hbs latte --check themes/latte.cfg
-# no output, exit code 0
+(no output, exit code 0)
 
 $ whiskers theme.hbs latte --check themes/latte.cfg
-Templating would result in changes:
- flavor: Latte
- 
- parent is default
-+accent is #ea76cb
--accent is #40a02b
+Templating would result in changes.
+4c4
+< accent is #ea76cb
+---
+> accent is #40a02b
 
-# exit code 1
+(exit code 1)
 ```
-
-This is especially useful in CI pipelines to ensure that the generated files are not changed without a corresponding change to the templates.
 
 ## Further Reading
 

--- a/whiskers/src/main.rs
+++ b/whiskers/src/main.rs
@@ -59,6 +59,7 @@ fn parse_override(s: &str) -> Result<Override> {
 }
 
 #[derive(clap::Parser, Debug)]
+#[command(author, version, about, long_about = None)]
 struct Args {
     /// Path to the template file to render, or `-` for stdin
     #[arg(required_unless_present = "list_helpers")]

--- a/whiskers/src/main.rs
+++ b/whiskers/src/main.rs
@@ -194,15 +194,35 @@ fn invoke_difftool(
 }
 
 fn print_diffs(actual: &str, expected: &str) {
+    fn maybe_paint(s: &str, c: ansiterm::Colour, tty: bool) {
+        if tty {
+            println!("{}", c.paint(s));
+        } else {
+            println!("{s}");
+        }
+    }
+
+    let tty = atty::is(atty::Stream::Stdout);
+    let sep = if tty { "│" } else { "|" };
+
     let diffs = diff::lines(actual, expected);
+    let mut li = 0;
+    let mut ri = 0;
+
     for diff in diffs {
         match diff {
             diff::Result::Left(l) => {
-                eprintln!("{}", ansiterm::Colour::Green.paint(format!("+{l}")));
+                li += 1;
+                maybe_paint(&format!("{li:4}{sep}+{l}"), ansiterm::Colour::Green, tty);
             }
-            diff::Result::Both(l, _) => eprintln!(" {l}"),
+            diff::Result::Both(l, _) => {
+                li += 1;
+                ri += 1;
+                println!("{li:4}{sep} {l}");
+            }
             diff::Result::Right(r) => {
-                eprintln!("{}", ansiterm::Colour::Red.paint(format!("-{r}")));
+                ri += 1;
+                maybe_paint(&format!("{ri:4}{sep}-{r}"), ansiterm::Colour::Red, tty);
             }
         }
     }


### PR DESCRIPTION
adds a new check/lint mode that returns 0 if the templated output matches the given file, and 1 if not. it also displays a diff using an external tool, preferring `$DIFFTOOL` but falling back to `diff` if necessary.

this change also removes the duplicated nix flake entry in the readme, matches the installation instructions more closely to catwalk's readme, and finally adds `--version`/`-V` flags to the cli.

# diff previews

<details><summary>delta (<a href="https://github.com/dandavison/delta">link</a>)</summary>
<p>

![delta](https://github.com/catppuccin/toolbox/assets/289746/8eb864ed-fd01-4611-be31-99be4017a5b3)

</p>
</details>

<details><summary>difftastic (<a href="https://github.com/Wilfred/difftastic">link</a>)</summary>
<p>

![difftastic](https://github.com/catppuccin/toolbox/assets/289746/b9456926-09ae-47e9-9393-201a494f2460)

</p>
</details>

<details><summary>icdiff (<a href="https://github.com/jeffkaufman/icdiff">link</a>)</summary>
<p>

![icdiff](https://github.com/catppuccin/toolbox/assets/289746/97dedbf3-6baf-4989-add4-8001b4c1966b)

</p>
</details>

BEGIN_COMMIT_OVERRIDE
feat(whiskers): add check mode with diff view
feat(whiskers): add version flag
END_COMMIT_OVERRIDE