### PR TITLE
feat: make input names optional, `-C` flag for directory, `--ext` for input file type

### DIFF
--- a/catwalk/src/cli.rs
+++ b/catwalk/src/cli.rs
@@ -1,16 +1,8 @@
+#![deny(clippy::perf, clippy::nursery, clippy::pedantic)]
 use catppuccin_catwalk::Layout;
-use clap::{Args, Command, Parser, Subcommand};
+use clap::{Command, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Generator, Shell};
 use std::path::PathBuf;
-
-#[derive(Args, Clone, Debug)]
-#[command(args_conflicts_with_subcommands(true))]
-pub struct ImageArgs {
-    pub latte: PathBuf,
-    pub frappe: PathBuf,
-    pub macchiato: PathBuf,
-    pub mocha: PathBuf,
-}
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum Commands {
@@ -21,25 +13,46 @@ pub enum Commands {
     },
 }
 
-#[derive(Parser, Clone, Debug)]
-#[command(author, version, about, long_about = None)]
-#[command(arg_required_else_help(true))]
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum Extension {
+    Webp,
+    Png,
+}
+
+#[derive(Parser)]
+#[command(author, version, about)]
 pub struct Cli {
-    /// Image inputs
-    #[command(flatten)]
-    pub images: Option<ImageArgs>,
+    /// Latte image
+    #[arg(default_value = "latte.webp")]
+    pub latte: Option<PathBuf>,
+    /// Frappé image
+    #[arg(default_value = "frappe.webp")]
+    pub frappe: Option<PathBuf>,
+    /// Macchiato image
+    #[arg(default_value = "macchiato.webp")]
+    pub macchiato: Option<PathBuf>,
+    /// Mocha image
+    #[arg(default_value = "mocha.webp")]
+    pub mocha: Option<PathBuf>,
     /// Output file
-    #[arg(short, long, default_value = "result.webp")]
+    #[arg(short, long, default_value = "preview.webp")]
     pub output: PathBuf,
     /// Layout
-    #[arg(short, long, value_enum)]
-    pub layout: Option<Layout>,
-    /// Gap (grid layout)
-    #[arg(short, long)]
-    pub gap: Option<u32>,
+    #[arg(short, long, value_enum, default_value_t=Layout::Composite)]
+    pub layout: Layout,
     /// Sets the radius (percentage)
     #[arg(short, long)]
     pub radius: Option<u32>,
+    /// Gap (grid layout)
+    #[arg(short, long)]
+    pub gap: Option<u32>,
+    /// Change to <DIRECTORY> before processing files
+    #[arg(short = 'C', long, default_value = ".")]
+    pub directory: Option<PathBuf>,
+    /// Extension to use when auto-detecting formats
+    #[arg(long = "ext", value_enum, default_value_t = Extension::Webp)]
+    pub extension: Extension,
+
     // Shell completion
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/catwalk/src/main.rs
+++ b/catwalk/src/main.rs
@@ -1,18 +1,29 @@
-#![cfg(not(target_family = "wasm"))]
+#![deny(clippy::perf, clippy::nursery, clippy::pedantic)]
 mod cli;
 
 use catppuccin_catwalk::Catwalk;
 use clap::CommandFactory;
-use cli::{get_cli_arguments, print_completions, Cli, Commands};
-use color_eyre::{
-    eyre::{eyre, Context},
-    Result,
-};
+use cli::{get_cli_arguments, print_completions, Cli, Commands, Extension};
+use color_eyre::{eyre::eyre, Result};
 use ril::prelude::*;
-use std::{io::Cursor, path::Path};
+use std::io::Cursor;
 
-fn open_rgba_image(path: &Path) -> Result<Image<Rgba>> {
-    Image::<Rgba>::open(path).map_or(Err(eyre!("Failed to open image")), Ok)
+macro_rules! open_image {
+    ($path:expr, $args:expr) => {{
+        let mut rel_path = $args.directory.clone().unwrap_or_default();
+        let path = $path.unwrap_or_default();
+        rel_path.push(path.clone());
+        match $args.extension {
+            Extension::Webp => {
+                rel_path.set_extension("webp");
+            }
+            Extension::Png => {
+                rel_path.set_extension("png");
+            }
+        }
+        Image::<Rgba>::open(&rel_path)
+            .map_or(Err(eyre!("Failed to open `{}`", &rel_path.display())), Ok)?
+    }};
 }
 
 fn main() -> Result<()> {
@@ -37,16 +48,14 @@ fn main() -> Result<()> {
         };
     }
 
-    let images = args.images.ok_or_else(|| eyre!("No images provided"))?;
-
     let catwalk = Catwalk::new([
-        open_rgba_image(&images.latte).context("Failed to open Latte image")?,
-        open_rgba_image(&images.frappe).context("Failed to open Frappé image")?,
-        open_rgba_image(&images.macchiato).context("Failed to open Macchiato image")?,
-        open_rgba_image(&images.mocha).context("Failed to open Mocha image")?,
+        open_image!(args.latte, args),
+        open_image!(args.frappe, args),
+        open_image!(args.macchiato, args),
+        open_image!(args.mocha, args),
     ])?
     .gap(args.gap)
-    .layout(args.layout)
+    .layout(Some(args.layout))
     .radius(args.radius)?
     .build()?;
 
@@ -71,6 +80,17 @@ fn main() -> Result<()> {
         },
     }
 
-    std::fs::write(args.output, writebuf.get_ref())
-        .map_err(|e| eyre!("Failed to write image: {}", e))
+    let output = if args.directory.is_some() {
+        let mut path = args.directory.clone().unwrap_or_default();
+        if args.output.is_absolute() {
+            args.output
+        } else {
+            path.push(args.output);
+            path
+        }
+    } else {
+        args.output
+    };
+
+    std::fs::write(output, writebuf.get_ref()).map_err(|e| eyre!("Failed to write image: {}", e))
 }


### PR DESCRIPTION
Adds `-C` to specify a directory for `catwalk`, also making all 4 image name arguments optional.
Adds `--ext` to specify file extension overrides when the inputs are omitted.
Changes the default output filename to `preview.webp` to standardize.

e.g.
```console
$ pwd
/home/user
$ catwalk -C ~/Code/catppuccin/vscode/assets 
```
Catwalk would open `latte.webp`, `frappe.webp`, `macchiato.webp`, `mocha.webp` in that directory, and write into `~/Code/catppuccin/vscode/assets/preview.webp`.

```console
$ pwd
/home/user
$ catwalk -C ~/Code/catppuccin/vscode/assets -o foo.webp
```
Writes to `~/Code/catppuccin/vscode/assets/foo.webp` to write to `/home/user/foo.webp`, specify `-o $PWD/foo.webp`.

`--ext` is added to change which file extensions for inputs it assumes, when unset.
```console
$ pwd
$ catwalk -C ~/Code/catppuccin/vscode/assets --ext png
```
Opens `latte.png`, `frappe.png`, `macchiato.png`, `mocha.png`; writes to `preview.webp`.