### PR TITLE
docs: add homebrew instructions

### DIFF
--- a/catwalk/README.md
+++ b/catwalk/README.md
@@ -20,8 +20,13 @@ Installation with Cargo, Nix, or from source:
 ```console
 $ cargo install catppuccin-catwalk
 $ catwalk <images> <flags>
+
 # to install from source:
 $ cargo install --git https://github.com/catppuccin/toolbox catwalk
+
+# if you're using Homebrew (or Linuxbrew):
+$ brew install catppuccin/tap/catwalk
+
 # there's also a Nix flake:
 $ nix run github:catppuccin/toolbox#catwalk -- <images> <flags>
 ```

--- a/whiskers/README.md
+++ b/whiskers/README.md
@@ -31,6 +31,9 @@ $ whiskers <template> <flavor>
 # to install from source:
 $ cargo install --git https://github.com/catppuccin/toolbox whiskers
 
+# if you're using Homebrew (or Linuxbrew):
+$ brew install catppuccin/tap/whiskers
+
 # there's also a Nix flake:
 $ nix run github:catppuccin/toolbox#whiskers -- <template> <flavor>
 ```


### PR DESCRIPTION
Closes #22
https://github.com/catppuccin/homebrew-tap is in a state where it can be used now.