### PR TITLE
chore(whiskers): don't specify patch version of deps

### DIFF
--- a/whiskers/Cargo.toml
+++ b/whiskers/Cargo.toml
@@ -14,17 +14,17 @@ name = "whiskers"
 path = "src/main.rs"
 
 [dependencies]
-base64 = "0.21.5"
-catppuccin = { version = "1.3.0", features = ["css"] }
-clap = { version = "4.4.8", features = ["derive"] }
-clap-stdin = "0.2.1"
-color-eyre = { version = "0.6.2", default-features = false }
-css-colors = "1.0.1"
-handlebars = "4.5.0"
-regex = "1.10.2"
-serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
-serde_yaml = "0.9.27"
-tempfile = "3.8.1"
-thiserror = "1.0.50"
-titlecase = "2.2.1"
+base64 = "0.21"
+catppuccin = { version = "1.3", features = ["css"] }
+clap = { version = "4.4", features = ["derive"] }
+clap-stdin = "0.2"
+color-eyre = { version = "0.6", default-features = false }
+css-colors = "1.0"
+handlebars = "4.5"
+regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+tempfile = "3.8"
+thiserror = "1.0"
+titlecase = "2.2"


### PR DESCRIPTION
#91 etc always bump workspace + whiskers which makes every patch appear in whiskers changelog.