### PR TITLE
fix: use hex -> rgb(a) without hsla where possible

### DIFF
--- a/whiskers/src/helper.rs
+++ b/whiskers/src/helper.rs
@@ -1,5 +1,5 @@
 use base64::Engine;
-use css_colors::{Color, Ratio, HSLA};
+use css_colors::{Color, Ratio, HSLA, RGBA};
 use handlebars::{
     handlebars_helper, Context, Handlebars, Helper, HelperResult, Output, RenderContext,
     RenderError,
@@ -8,7 +8,7 @@ use handlebars::{
 use ::titlecase::titlecase as titlecase_ext;
 use serde_json::Value;
 
-use crate::parse::HSLAExt;
+use crate::parse::ColorExt;
 
 impl From<crate::parse::Error> for RenderError {
     fn from(value: crate::parse::Error) -> Self {
@@ -33,10 +33,10 @@ handlebars_helper!(opacity: |color: String, amount: f32| {
     HSLA::from_hex(&color)?.fade(Ratio::from_f32(amount)).to_hex()
 });
 handlebars_helper!(rgb: |color: String| {
-    HSLA::from_hex(&color)?.to_rgb().to_string()
+    RGBA::from_hex(&color)?.to_rgb().to_string()
 });
 handlebars_helper!(rgba: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().to_string()
+    RGBA::from_hex(&color)?.to_string()
 });
 handlebars_helper!(hsl: |color: String| {
     HSLA::from_hex(&color)?.to_hsl().to_string()
@@ -45,28 +45,28 @@ handlebars_helper!(hsla: |color: String| {
     HSLA::from_hex(&color)?.to_string()
 });
 handlebars_helper!(red_i: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().r.as_u8()
+    RGBA::from_hex(&color)?.r.as_u8()
 });
 handlebars_helper!(green_i: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().g.as_u8()
+    RGBA::from_hex(&color)?.g.as_u8()
 });
 handlebars_helper!(blue_i: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().b.as_u8()
+    RGBA::from_hex(&color)?.b.as_u8()
 });
 handlebars_helper!(alpha_i: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().a.as_u8()
+    RGBA::from_hex(&color)?.a.as_u8()
 });
 handlebars_helper!(red_f: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().r.as_f32()
+    RGBA::from_hex(&color)?.r.as_f32()
 });
 handlebars_helper!(green_f: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().g.as_f32()
+    RGBA::from_hex(&color)?.g.as_f32()
 });
 handlebars_helper!(blue_f: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().b.as_f32()
+    RGBA::from_hex(&color)?.b.as_f32()
 });
 handlebars_helper!(alpha_f: |color: String| {
-    HSLA::from_hex(&color)?.to_rgba().a.as_f32()
+    RGBA::from_hex(&color)?.a.as_f32()
 });
 
 pub fn darklight(

--- a/whiskers/src/parse.rs
+++ b/whiskers/src/parse.rs
@@ -12,8 +12,8 @@ pub enum Error {
     ParseInt(ParseIntError),
 }
 
-pub trait HSLAExt {
-    fn from_hex(hex: &str) -> Result<HSLA, Error>;
+pub trait ColorExt<T: Color> {
+    fn from_hex(hex: &str) -> Result<T, Error>;
     fn to_hex(&self) -> String;
 }
 
@@ -24,7 +24,7 @@ fn hex_to_u8s(hex: &str) -> Result<Vec<u8>, ParseIntError> {
         .collect()
 }
 
-impl HSLAExt for HSLA {
+impl ColorExt<Self> for RGBA {
     fn from_hex(hex: &str) -> Result<Self, Error> {
         if hex.len() != 6 && hex.len() != 8 {
             return Err(Error::InvalidLength(hex.len()));
@@ -36,7 +36,7 @@ impl HSLAExt for HSLA {
             .expect("guaranteed to have at least 3 elements");
         let alpha = components.get(3).copied().unwrap_or(255);
 
-        Ok(rgba(red, green, blue, Ratio::from_u8(alpha).as_f32()).to_hsla())
+        Ok(rgba(red, green, blue, Ratio::from_u8(alpha).as_f32()))
     }
 
     fn to_hex(&self) -> String {
@@ -44,7 +44,7 @@ impl HSLAExt for HSLA {
             let RGB { r, g, b } = self.to_rgb();
             format!("{:02x}{:02x}{:02x}", r.as_u8(), g.as_u8(), b.as_u8())
         } else {
-            let RGBA { r, g, b, a } = self.to_rgba();
+            let Self { r, g, b, a } = self;
             format!(
                 "{:02x}{:02x}{:02x}{:02x}",
                 r.as_u8(),
@@ -53,6 +53,16 @@ impl HSLAExt for HSLA {
                 a.as_u8()
             )
         }
+    }
+}
+
+impl ColorExt<Self> for HSLA {
+    fn from_hex(hex: &str) -> Result<Self, Error> {
+        Ok(RGBA::from_hex(hex)?.to_hsla())
+    }
+
+    fn to_hex(&self) -> String {
+        self.to_rgba().to_hex()
     }
 }
 


### PR DESCRIPTION
fixes #90 by cutting out the hsla step in colour conversions where possible.

there will still be some value drift if we were to do something like lighten(10) -> darken(10) -> rgba, but at that point you're intentionally trying to break things.