### PR TITLE
feat(whiskers): add colors object in context

### DIFF
--- a/whiskers/src/template.rs
+++ b/whiskers/src/template.rs
@@ -193,11 +193,13 @@ pub fn make_context(flavor: catppuccin::Flavour) -> serde_json::Value {
         .collect();
 
     let mut context =
-        serde_json::to_value(color_map).expect("color names & hexcodes can be serialized");
+        serde_json::to_value(color_map.clone()).expect("color names & hexcodes can be serialized");
 
     context["flavor"] = flavor.name().into();
     context["isLight"] = (flavor == catppuccin::Flavour::Latte).into();
     context["isDark"] = (flavor != catppuccin::Flavour::Latte).into();
+    context["colors"] =
+        serde_json::to_value(color_map).expect("color names & hexcodes can be serialized");
 
     context
 }


### PR DESCRIPTION
I saw https://github.com/catppuccin/go/pull/10 and was kinda surprised that we overlooked iterating colors, again.

This shortens the whole go lib template to:
```hbs
package catppuccingo

type {{flavor}} struct{}

// {{titlecase flavor}} flavour variant.
var {{titlecase flavor}} Flavour = {{flavor}}{}

func ({{flavor}}) Name() string { return "{{flavor}}" }

{{ #each colors as | color colorName | }}
func ({{@root/flavor}}) {{titlecase colorName}}() Color {
	return Color{
		Hex: "#{{ color }}",
		RGB: [3]uint32{ {{ red_i color }}, {{ green_i color }}, {{ blue_i color }}},
		HSL: [3]float32{ {{ hsl color }}},
	}
}

{{/each}}
```