### PR TITLE
ci: add Renovate deno configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "github>Omochice/renovate-config:deno"
   ]
 }


### PR DESCRIPTION
Allows us to bump the `deno-lib` imports via Renovate 😌 