### PR TITLE
build(deno-lib): fix imports for renovate

### DIFF
--- a/deno-lib/validateYaml.ts
+++ b/deno-lib/validateYaml.ts
@@ -1,4 +1,4 @@
-import Ajv, { type Schema } from "https://esm.sh/v135/ajv@8.12.0";
+import Ajv, { type Schema } from "https://esm.sh/ajv@8.12.0?pin=v135";
 import { parse } from "https://deno.land/std@0.207.0/yaml/parse.ts";
 
 /**

--- a/deno.lock
+++ b/deno.lock
@@ -65,7 +65,7 @@
     "https://deno.land/std@0.207.0/yaml/schema/json.ts": "5f41dd7c2f1ad545ef6238633ce9ee3d444dfc5a18101e1768bd5504bf90e5e5",
     "https://deno.land/std@0.207.0/yaml/schema/mod.ts": "4472e827bab5025e92bc2eb2eeefa70ecbefc64b2799b765c69af84822efef32",
     "https://deno.land/std@0.207.0/yaml/type.ts": "65553da3da3c029b6589c6e4903f0afbea6768be8fca61580711457151f2b30f",
-    "https://esm.sh/v135/ajv@8.12.0": "cc1a73af661466c7f4e6a94d93ece78542d700f2165bdb16a531e9db8856c5aa",
+    "https://esm.sh/ajv@8.12.0?pin=v135": "cc1a73af661466c7f4e6a94d93ece78542d700f2165bdb16a531e9db8856c5aa",
     "https://esm.sh/v135/ajv@8.12.0/denonext/ajv.mjs": "4645df9093d0f8be0e964070a4a7aea8adea06e8883660340931f7a3f979fc65",
     "https://esm.sh/v135/fast-deep-equal@3.1.3/denonext/fast-deep-equal.mjs": "6313b3e05436550e1c0aeb2a282206b9b8d9213b4c6f247964dd7bb4835fb9e5",
     "https://esm.sh/v135/json-schema-traverse@1.0.0/denonext/json-schema-traverse.mjs": "c5da8353bc014e49ebbb1a2c0162d29969a14c325da19644e511f96ba670cc45",


### PR DESCRIPTION
Discovered a bug in that Renovate config, workaround for now.