### PR TITLE
feat(catwalk): use ril with pure rust webp feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,8 +641,7 @@ dependencies = [
 [[package]]
 name = "image-webp"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a84a25dcae3ac487bc24ef280f9e20c79c9b1a3e5e32cbed3041d1c514aa87c"
+source = "git+https://github.com/image-rs/image-webp#4020925b7002bac88cda9f951eb725f6a7fcd3d8"
 dependencies = [
  "byteorder",
  "thiserror",
@@ -1013,7 +1012,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 [[package]]
 name = "ril"
 version = "0.10.1"
-source = "git+https://github.com/nekowinston/ril?branch=feat/image_webp#29410372508a6b42523a768859e95d7c914b1c06"
+source = "git+https://github.com/nekowinston/ril?rev=88d559706bd084468a95723d42910140803cb090#88d559706bd084468a95723d42910140803cb090"
 dependencies = [
  "fast_image_resize",
  "image-webp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "image-webp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a84a25dcae3ac487bc24ef280f9e20c79c9b1a3e5e32cbed3041d1c514aa87c"
+dependencies = [
+ "byteorder",
+ "thiserror",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,19 +706,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libwebp-sys2"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2ae528b6c8f543825990b24c00cfd8fe64dde126c8288f4972b18e3d558072"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -888,12 +885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "png"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,11 +1013,10 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 [[package]]
 name = "ril"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9d89f558ed427b172d6014c4cf3145b506d379df0676b471964dbbbe923ea1"
+source = "git+https://github.com/nekowinston/ril?branch=feat/image_webp#29410372508a6b42523a768859e95d7c914b1c06"
 dependencies = [
  "fast_image_resize",
- "libwebp-sys2",
+ "image-webp",
  "num-traits",
  "png",
 ]
@@ -1330,12 +1320,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/catwalk/Cargo.toml
+++ b/catwalk/Cargo.toml
@@ -21,19 +21,19 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 thiserror = "1"
 
+[dependencies.ril]
+git = "https://github.com/nekowinston/ril"
+branch = "feat/image_webp"
+default-features = false
+features = ["png", "resize", "webp-pure"]
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4" }
 color-eyre = { version = "0.6", default-features = false }
-ril = { version = "0.10", default-features = false, features = [
-  "png",
-  "resize",
-  "webp",
-] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3"
-ril = { version = "0.10", default-features = false }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["ImageData"] }
 getrandom = { version = "0.2", features = ["js"] }

--- a/catwalk/Cargo.toml
+++ b/catwalk/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1"
 
 [dependencies.ril]
 git = "https://github.com/nekowinston/ril"
-branch = "feat/image_webp"
+rev = "88d559706bd084468a95723d42910140803cb090"
 default-features = false
 features = ["png", "resize", "webp-pure"]
 

--- a/catwalk/src/main.rs
+++ b/catwalk/src/main.rs
@@ -66,22 +66,11 @@ fn main() -> Result<()> {
     match args.output.extension() {
         None => return Err(eyre!("Output file type could not be determined")),
         Some(os_str) => match os_str.to_str() {
-            Some("png") => {
-                use ril::encodings::png::PngEncoder;
-
-                PngEncoder::encode_static(&catwalk, &mut writebuf)?;
-            }
-            Some("webp") => {
-                use ril::encodings::webp::{WebPEncoderOptions, WebPStaticEncoder};
-
-                let opt = WebPEncoderOptions::new().with_lossless(true);
-                let meta = EncoderMetadata::<Rgba>::from(&catwalk).with_config(opt);
-                let mut encoder = WebPStaticEncoder::new(&mut writebuf, meta)?;
-                encoder.add_frame(&catwalk)?;
-            }
+            Some("png") => catwalk.encode(ImageFormat::Png, &mut writebuf)?,
+            Some("webp") => catwalk.encode(ImageFormat::WebP, &mut writebuf)?,
             _ => return Err(eyre!("Output file type not supported")),
         },
-    }
+    };
 
     let output = if args.directory.is_some() {
         let mut path = args.directory.clone().unwrap_or_default();
@@ -95,5 +84,7 @@ fn main() -> Result<()> {
         args.output
     };
 
-    std::fs::write(output, writebuf.get_ref()).map_err(|e| eyre!("Failed to write image: {}", e))
+    // std::fs::write(output, writebuf.get_ref()).map_err(|e| eyre!("Failed to write image: {}", e))
+    catwalk.save_inferred(output)?;
+    Ok(())
 }

--- a/catwalk/src/main.rs
+++ b/catwalk/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
         args.output
     };
 
-    // std::fs::write(output, writebuf.get_ref()).map_err(|e| eyre!("Failed to write image: {}", e))
-    catwalk.save_inferred(output)?;
-    Ok(())
+    catwalk
+        .save_inferred(output)
+        .map_err(|e| eyre!("Failed to write image: {}", e))
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -27,6 +27,11 @@
       nativeBuildInputs = with pkgs; [installShellFiles pkg-config];
       buildInputs = with pkgs; [libwebp];
 
+      cargoLock.outputHashes = {
+        "image-webp-0.1.1" = "sha256-WlGXjvkw6JL8OsS9IoM5Fpd4au8zp9jO/Z2iTXQE2Ko=";
+        "ril-0.10.1" = "sha256-xVkuR8m6Q91Ii+bbCD9+foyka5a0vpJwTHBM8Hjjt4I=";
+      };
+
       postInstall = ''
         installShellCompletion --cmd catwalk \
           --bash <($out/bin/catwalk completion bash) \

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,14 @@
         inherit (memberCargoToml.package) version;
         src = pkgs.nix-gitignore.gitignoreSource [] ../.;
 
-        cargoLock.lockFile = ../Cargo.lock;
+        cargoLock = {
+          lockFile = ../Cargo.lock;
+          outputHashes = {
+            "image-webp-0.1.1" = "sha256-WlGXjvkw6JL8OsS9IoM5Fpd4au8zp9jO/Z2iTXQE2Ko=";
+            "ril-0.10.1" = "sha256-xVkuR8m6Q91Ii+bbCD9+foyka5a0vpJwTHBM8Hjjt4I=";
+          };
+        };
+
         buildAndTestSubdir = pname;
 
         meta = {
@@ -26,11 +33,6 @@
     catwalk = {
       nativeBuildInputs = with pkgs; [installShellFiles pkg-config];
       buildInputs = with pkgs; [libwebp];
-
-      cargoLock.outputHashes = {
-        "image-webp-0.1.1" = "sha256-WlGXjvkw6JL8OsS9IoM5Fpd4au8zp9jO/Z2iTXQE2Ko=";
-        "ril-0.10.1" = "sha256-xVkuR8m6Q91Ii+bbCD9+foyka5a0vpJwTHBM8Hjjt4I=";
-      };
 
       postInstall = ''
         installShellCompletion --cmd catwalk \


### PR DESCRIPTION
Closes #133, moving all the dependencies to native Rust instead of binding to libwebp-sys.