### PR TITLE
ci(release-please): add manual trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,7 @@
 name: release-please
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
This commit allows us to manually trigger
release please. Mostly for regenerating
changelogs based on updating closed PRs.
