### PR TITLE
feat(whiskers): add colors to context in single-flavor matrix

### DIFF
--- a/whiskers/src/main.rs
+++ b/whiskers/src/main.rs
@@ -318,6 +318,11 @@ fn render_multi_output(
                 let flavor: catppuccin::FlavorName = value.parse()?;
                 let flavor = &palette.flavors[flavor.identifier()];
                 ctx.insert("flavor", flavor);
+
+                // also throw in the flavor's colors for convenience
+                for (_, color) in flavor {
+                    ctx.insert(&color.identifier, &color);
+                }
             } else {
                 ctx.insert(key, &value);
             }

--- a/whiskers/tests/fixtures/multifile.tera
+++ b/whiskers/tests/fixtures/multifile.tera
@@ -10,3 +10,4 @@ whiskers:
 # Catppuccin {{flavor.name}}{% if variant == "no-italics" %} (no italics){% endif %}
 [theme]
 {{accent}}: #{{flavor.colors[accent].hex}}
+rosewater: {{rosewater.hex}}


### PR DESCRIPTION
Since I'm not familiar with the code, this is just a quick copy-paste, from here:
https://github.com/catppuccin/toolbox/blob/052482d8c702b4747ef97a507ca8d749e4a75b76/whiskers/src/main.rs#L137-L140-144

Would close #177.