### PR TITLE
ci(release-please): use action from `googleapis`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         if: ${{ !env.ACT }}
     outputs:


### PR DESCRIPTION
I confirmed that it shouldn't break anything
from looking at the documentation, but who
knows with release-please /shrug

Closes #232
